### PR TITLE
Fix #32

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -450,7 +450,7 @@ impl Instruction {
             0xff => Instruction::SELFDESTRUCT,
             // Unknown
             _ => {
-                panic!("Unknown instruction encountered ({:#2x})",opcode);
+                Instruction::DATA(vec![opcode])
             }
         };
         //


### PR DESCRIPTION
This puts through a simple fix for decoding invalid bytecodes. Specifically, it always generates a `DATA` instruction in this case.