### PR TITLE
Implement basic disassembler #126

### DIFF
--- a/src/bin/evmil.rs
+++ b/src/bin/evmil.rs
@@ -18,7 +18,7 @@ use log4rs::append::console::ConsoleAppender;
 use log4rs::config::{Appender, Config, Root};
 use log4rs::encode::pattern::PatternEncoder;
 //
-use evmil::evm::{Assembly,Section};
+use evmil::evm::{Assembly,AssemblyInstruction,Section};
 use evmil::evm::{eof,legacy};
 use evmil::il::{Compiler,Parser};
 use evmil::util::{FromHexString, ToHexString};
@@ -128,14 +128,22 @@ fn disassemble(args: &ArgMatches) -> Result<bool, Box<dyn Error>> {
         legacy::from_bytes(&bytes)
     };
     // Convert it into assembly language
-    let asm = bytecode; // FOR NOW!
+    let asm = Assembly::from(&bytecode);
     // Iterate bytecode sections
     for section in &asm {
         match section {
             Section::Code(insns,_,_,_) => {
                 println!(".code");
                 for insn in insns {
-                    println!("\t{}",insn);
+                    match insn {
+                        AssemblyInstruction::LABEL(_) => {
+                            println!("{insn}")
+                        }
+                        _ => {
+                            println!("\t{insn}")
+                        }
+                    }
+
                 }
             }
             Section::Data(bytes) => {

--- a/src/evm/disassembler/mod.rs
+++ b/src/evm/disassembler/mod.rs
@@ -1,0 +1,164 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::collections::HashMap;
+use crate::evm::{Instruction,AssemblyInstruction};
+
+use crate::evm::AbstractInstruction::*;
+
+pub fn disassemble(bytecodes: &[Instruction]) -> Vec<AssemblyInstruction> {
+    let mut count = 0;
+    let mut pc = 0;
+    // Identify and allocate all labels
+    let mut labels = HashMap::new();
+    for b in bytecodes {
+        //
+        match b {
+            RJUMP(r16)|RJUMPI(r16) => {
+                let target = from_rel_offset(pc+3,*r16);
+                // Allocate label (if not already)
+                if !labels.contains_key(&target) {
+                    labels.insert(target,format!("lab{count}"));
+                    count += 1;
+                }
+            }
+            _ => {}
+        }
+        //
+        pc += b.length();
+    }
+    // Translate all instructions whilst inserting labels.
+    pc = 0;
+    let mut asm = Vec::new();
+    //
+    for b in bytecodes {
+        if labels.contains_key(&pc) {
+            asm.push(LABEL(labels[&pc].clone()));
+        }
+        asm.push(translate_insn(pc,b,&labels));
+        pc += b.length();
+    }
+    // Done
+    asm
+}
+
+fn translate_insn(pc: usize, insn: &Instruction, labels: &HashMap<usize,String>) -> AssemblyInstruction {
+    match insn {
+        // 0s: Stop and Arithmetic Operations
+        STOP => STOP,
+        ADD => ADD,
+        MUL => MUL,
+        SUB => SUB,
+        DIV => DIV,
+        SDIV => SDIV,
+        MOD => MOD,
+        SMOD => SMOD,
+        ADDMOD => ADDMOD,
+        MULMOD => MULMOD,
+        EXP => EXP,
+        SIGNEXTEND => SIGNEXTEND,
+        // 10s: Comparison & Bitwise Logic Operations
+        LT => LT,
+        GT => GT,
+        SLT => SLT,
+        SGT => SGT,
+        EQ => EQ,
+        ISZERO => ISZERO,
+        AND => AND,
+        OR => OR,
+        XOR => XOR,
+        NOT => NOT,
+        BYTE => BYTE,
+        SHL => SHL,
+        SHR => SHR,
+        SAR => SAR,
+        // 20s: Keccak256
+        KECCAK256 => KECCAK256,
+        // 30s: Environmental Information
+        ADDRESS => ADDRESS,
+        BALANCE => BALANCE,
+        ORIGIN => ORIGIN,
+        CALLER => CALLER,
+        CALLVALUE => CALLVALUE,
+        CALLDATALOAD => CALLDATALOAD,
+        CALLDATASIZE => CALLDATASIZE,
+        CALLDATACOPY => CALLDATACOPY,
+        CODESIZE => CODESIZE,
+        CODECOPY => CODECOPY,
+        GASPRICE => GASPRICE,
+        EXTCODESIZE => EXTCODESIZE,
+        EXTCODECOPY => EXTCODECOPY,
+        RETURNDATASIZE => RETURNDATASIZE,
+        RETURNDATACOPY => RETURNDATACOPY,
+        EXTCODEHASH => EXTCODEHASH,
+        // 40s: Block Information
+        BLOCKHASH => BLOCKHASH,
+        COINBASE => COINBASE,
+        TIMESTAMP => TIMESTAMP,
+        NUMBER => NUMBER,
+        DIFFICULTY => DIFFICULTY,
+        GASLIMIT => GASLIMIT,
+        CHAINID => CHAINID,
+        SELFBALANCE => SELFBALANCE,
+        // 50s: Stack, Memory, Storage and Flow Operations
+        POP => POP,
+        MLOAD => MLOAD,
+        MSTORE => MSTORE,
+        MSTORE8 => MSTORE8,
+        SLOAD => SLOAD,
+        SSTORE => SSTORE,
+        JUMP => JUMP,
+        JUMPI => JUMPI,
+        PC => PC,
+        MSIZE => MSIZE,
+        GAS => GAS,
+        JUMPDEST => JUMPDEST,
+        RJUMP(r16) => {
+            let target = from_rel_offset(pc+3,*r16);
+            RJUMP(labels[&target].clone())
+        }
+        RJUMPI(r16) => {
+            let target = from_rel_offset(pc+3,*r16);
+            RJUMPI(labels[&target].clone())
+        }
+        // 60s & 70s: Push Operations
+        PUSH(bs) => PUSH(bs.clone()),
+        // 80s: Duplication Operations
+        DUP(n) => DUP(*n),
+        // 90s: Swap Operations
+        SWAP(n) => SWAP(*n),
+        // a0s: Log Operations
+        LOG(n) => LOG(*n),
+        // f0s: System Operations
+        CREATE => CREATE,
+        CALL => CALL,
+        CALLCODE => CALLCODE,
+        RETURN => RETURN,
+        DELEGATECALL => DELEGATECALL,
+        CREATE2 => CREATE2,
+        STATICCALL => STATICCALL,
+        REVERT => REVERT,
+        INVALID => INVALID,
+        SELFDESTRUCT => SELFDESTRUCT,
+        DATA(bs) => DATA(bs.clone()),
+        //
+        PUSHL(_)|LABEL(_) => unreachable!(),
+    }
+}
+
+/// Calculate the absolute byte offset of a given relative jump target
+/// from a given `pc` position (which is the `pc` after the
+/// instruction in question).
+fn from_rel_offset(pc: usize, rel: i16) -> usize {
+    let mut r = pc as isize;
+    r += rel as isize;
+    r as usize
+}

--- a/src/evm/instruction/abstract.rs
+++ b/src/evm/instruction/abstract.rs
@@ -6,11 +6,11 @@ use crate::util::{ToHexString};
 /// to support different forms of control flow.
 pub trait InstructionOperands {
     /// Identifies the type of 16bit relative offsets.
-    type RelOffset16 : Debug;
+    type RelOffset16 : fmt::Display+Debug;
     /// Identifies the type for _push label_ instructions.
-    type PushLabel : Debug;
+    type PushLabel : fmt::Display+Debug;
     /// Identifies the type for _label_ instructions.
-    type Label : Debug;
+    type Label : fmt::Display+Debug;
 }
 
 /// A void operand is used to signal that something is impossible
@@ -18,6 +18,12 @@ pub trait InstructionOperands {
 /// setting, etc).
 #[derive(Clone,Debug,PartialEq)]
 pub enum VoidOperand{}
+
+impl fmt::Display for VoidOperand {
+    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        unreachable!()
+    }
+}
 
 /// An abstract instruction is parameterised over the type of _control
 /// flow_ it supports.  In particular, _concrete_ instructions are
@@ -170,6 +176,9 @@ impl<T:InstructionOperands+Debug> fmt::Display for AbstractInstruction<T> {
             AbstractInstruction::DUP(n) => {
                 write!(f, "dup{}",n)
             }
+            AbstractInstruction::LABEL(lab) => {
+                write!(f, "{lab}:")
+            }
             AbstractInstruction::LOG(n) => {
                 write!(f, "log{n}")
             }
@@ -183,10 +192,10 @@ impl<T:InstructionOperands+Debug> fmt::Display for AbstractInstruction<T> {
                 write!(f, "push {}", hex)
             }
             AbstractInstruction::RJUMP(offset) => {
-                write!(f, "rjump {offset:?}")
+                write!(f, "rjump {offset}")
             }
             AbstractInstruction::RJUMPI(offset) => {
-                write!(f, "rjumpi {offset:?}")
+                write!(f, "rjumpi {offset}")
             }
             AbstractInstruction::SWAP(n) => {
                 write!(f, "swap{n}")

--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -12,6 +12,7 @@
 
 mod assembler;
 mod bytecode;
+mod disassembler;
 mod fork;
 mod instruction;
 pub mod legacy;


### PR DESCRIPTION
This implements a basic disassembler which works reasonably well for EOF bytecodes (i.e. `RJUMP` and `RJUMPI`), but does not work well for legacy bytecodes (i.e. `JUMP` and `JUMPI`).

The next step is to figure out the legacy issue.