### PR TITLE
Remove meta information on `Section::Code`

### DIFF
--- a/src/bin/evmil.rs
+++ b/src/bin/evmil.rs
@@ -132,7 +132,7 @@ fn disassemble(args: &ArgMatches) -> Result<bool, Box<dyn Error>> {
     // Iterate bytecode sections
     for section in &asm {
         match section {
-            Section::Code(insns,_,_,_) => {
+            Section::Code(insns) => {
                 println!(".code");
                 for insn in insns {
                     match insn {

--- a/src/evm/assembler/parser.rs
+++ b/src/evm/assembler/parser.rs
@@ -102,7 +102,7 @@ fn parse_code_section(lexer: &mut Lexer) -> Result<Section<AssemblyInstruction>,
                 insns.push(LABEL(s.to_string()));
             }
             Token::EOF|Token::Section(_) => {
-                return Ok(Section::Code(insns,0,0,0));
+                return Ok(Section::Code(insns));
             }
             _ => {
                 // Something went wrong

--- a/src/evm/eof.rs
+++ b/src/evm/eof.rs
@@ -175,11 +175,12 @@ pub fn from_bytes(bytes: &[u8]) -> Result<Bytecode<Instruction>,DecodingError> {
     for i in 0..num_code_sections {
         let bytes = iter.decode_bytes(code_sizes[i])?;
         // Recall type information
-        let (inputs,outputs,max_stack) = types[i];
+        let (_inputs,_outputs,_max_stack) = types[i];
         // Convert byte sequence into an instruction sequence.
         let insns = bytes.to_insns();
         // Add code section
-        code.add(Section::Code(insns,inputs,outputs,max_stack))
+        code.add(Section::Code(insns));
+        // Validate types information?
     }
     // parse data sectin (if present)
     let data = iter.decode_bytes(data_size)?.to_vec();
@@ -200,7 +201,7 @@ pub fn to_bytes(bytecode: Bytecode<Instruction>) -> Result<Vec<u8>,EncodingError
     // Count number of code contracts (to be deprecated?)
     for section in &bytecode {
         match section {
-            Section::Code(_,_,_,_) => {
+            Section::Code(_) => {
                 if data_section != None {
                     return Err(EncodingError::DataSectionNotLast)
                 }
@@ -250,10 +251,11 @@ pub fn to_bytes(bytecode: Bytecode<Instruction>) -> Result<Vec<u8>,EncodingError
     // Write types data
     for section in &bytecode {
         match section {
-            Section::Code(_,inputs,outputs,max_stack) => {
-                bytes.encode_u8(*inputs);
-                bytes.encode_u8(*outputs);
-                bytes.encode_u16(*max_stack);
+            Section::Code(_) => {
+                // FIXME: infer necessary information.
+                bytes.encode_u8(0);
+                bytes.encode_u8(0);
+                bytes.encode_u16(0);
             }
             _ => {}
         }

--- a/src/il/compiler.rs
+++ b/src/il/compiler.rs
@@ -60,7 +60,7 @@ impl Compiler {
 
     pub fn to_assembly(self) -> Assembly {
         let mut sections = Vec::new();
-        sections.push(Section::Code(self.bytecode,0,0,0));
+        sections.push(Section::Code(self.bytecode));
         Assembly::new(sections)
     }
 


### PR DESCRIPTION
This removes the EOF meta information from the `Section::Code`. Instead, this information should be inferred on demand.