### PR TITLE
Support assembler comments

### DIFF
--- a/src/evm/assembler/parser.rs
+++ b/src/evm/assembler/parser.rs
@@ -25,6 +25,7 @@ use super::lexer::{Lexer,Token};
 #[derive(Debug)]
 pub enum AssemblyError {
     ExpectedOperand,
+    InvalidComment(usize),
     InvalidHexString(usize),
     InvalidInstruction,
     UnexpectedCharacter(usize),
@@ -323,6 +324,7 @@ fn parse_opcode(insn: &str) -> Result<AssemblyInstruction,AssemblyError> {
         "selfdestruct"|"SELFDESTRUCT" => SELFDESTRUCT,
         //
         _ => {
+            println!("{insn}");
             return Err(AssemblyError::InvalidInstruction);
         }
     };


### PR DESCRIPTION
This enables support for comments in the assembly language, which start with ';'.  At this stage, however, comments are discarded.  At some point, it might be useful to retain "doc comments".